### PR TITLE
Run all After methods whose Before methods were executed successfully

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -74,9 +74,6 @@ func (handy *Handy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	for k, interceptor := range interceptors {
 		interceptor.Before(w, r)
 		if w.status > 0 || w.Written {
-			if k > 0 {
-				k--
-			}
 			interceptors = interceptors[:k]
 			goto write
 		}


### PR DESCRIPTION
Handy wasn't running all After methods from the interceptors that were executed successfully. It was ignoring the last one. For example:

```
i1 -> i2 -> i3 -> i4
```

With an error on i4 handy was only executing:

```
i2 -> i1
```

And forgetting about i3.
