### PR TITLE
Avoid concurrency

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -12,6 +12,10 @@ var (
 	Logger *log.Logger
 )
 
+func init() {
+	Logger = log.New(os.Stdout, "[handy] ", 0)
+}
+
 type Handy struct {
 	mu             sync.RWMutex
 	router         *Router
@@ -25,7 +29,6 @@ type HandyFunc func() Handler
 func NewHandy() *Handy {
 	handy := new(Handy)
 	handy.router = NewRouter()
-	Logger = log.New(os.Stdout, "[handy] ", 0)
 	return handy
 }
 

--- a/router.go
+++ b/router.go
@@ -67,16 +67,6 @@ func (r *Router) AppendRoute(uri string, h HandyFunc) error {
 		r.current = r.root
 	}()
 
-	// Special case, appending root
-	if uri == "/" {
-		if r.root.handler != nil {
-			return ErrRouteAlreadyExists
-		}
-
-		r.root.handler = h
-		return nil
-	}
-
 	appended := false
 	tokens := strings.Split(uri, "/")
 	for i, v := range tokens {
@@ -160,7 +150,7 @@ func (r *Router) Match(uri string) (*RouteMatch, error) {
 
 		n := current.findChild(v)
 		if n == nil {
-			break
+			return rt, ErrRouteNotFound
 		}
 
 		if n.isWildcard {

--- a/router_test.go
+++ b/router_test.go
@@ -31,11 +31,6 @@ func TestAppendRoute(t *testing.T) {
 	if err == nil {
 		t.Fatal("Appending the same route twice", err)
 	}
-
-	err = rt.AppendRoute("/", func() Handler { return h })
-	if err != nil {
-		t.Fatal("Cannot append root", err)
-	}
 }
 
 func TestAppendWildCard(t *testing.T) {
@@ -74,21 +69,6 @@ func TestFindRoute(t *testing.T) {
 	route, err := rt.Match("/test")
 	if err != nil {
 		t.Fatal("Cannot find a valid route;", err)
-	}
-
-	route, err = rt.Match("/test/test")
-	if err != nil {
-		t.Fatal("Not falling back to parent handler;", err)
-	}
-
-	err = rt.AppendRoute("/another/{param}", func() Handler { return h })
-	if err != nil {
-		t.Fatal("Cannot append a valid route", err)
-	}
-
-	route, err = rt.Match("/another/{param}/test")
-	if err != nil {
-		t.Fatal("Not falling back to parent handler;", err)
 	}
 
 	t.Log(route.URIVars)


### PR DESCRIPTION
When two go routines call NewHandy function at the same time we got a concurrency problem because of the Logger global variable. We can solve this moving the assignment to an init function.
