### PR TITLE
Fix HTTP status code when route was not found

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -63,7 +63,10 @@ func (handy *Handy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	route, err := handy.router.Match(r.URL.Path)
 	if err != nil {
-		http.Error(rw, "", http.StatusServiceUnavailable)
+		// http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5
+		// The server has not found anything matching the Request-URI. No indication is given of whether
+		// the condition is temporary or permanent.
+		http.NotFound(rw, r)
 		return
 	}
 


### PR DESCRIPTION
404 Not Found

The server has not found anything matching the Request-URI. No indication is given of whether the condition is temporary or permanent. The 410 (Gone) status code SHOULD be used if the server knows, through some internally configurable mechanism, that an old resource is permanently unavailable and has no forwarding address. This status code is commonly used when the server does not wish to reveal exactly why the request has been refused, or when no other response is applicable. 
