### PR TITLE
Expose URI

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -10,7 +10,7 @@ type Handler interface {
 	Patch() int
 	Head() int
 	Interceptors() InterceptorChain
-	setRequestInfo(w http.ResponseWriter, r *http.Request, u URIVars)
+	setRequestInfo(w http.ResponseWriter, r *http.Request, uri string, u URIVars)
 }
 
 type DefaultHandler struct {
@@ -18,6 +18,7 @@ type DefaultHandler struct {
 
 	response http.ResponseWriter
 	request  *http.Request
+	uri      string
 	uriVars  URIVars
 }
 
@@ -53,10 +54,14 @@ func (d *DefaultHandler) Req() *http.Request {
 	return d.request
 }
 
+func (d *DefaultHandler) URI() string {
+	return d.uri
+}
+
 func (d *DefaultHandler) URIVars() URIVars {
 	return d.uriVars
 }
 
-func (d *DefaultHandler) setRequestInfo(w http.ResponseWriter, r *http.Request, u URIVars) {
-	*d = DefaultHandler{response: w, request: r, uriVars: u}
+func (d *DefaultHandler) setRequestInfo(w http.ResponseWriter, r *http.Request, uri string, u URIVars) {
+	*d = DefaultHandler{response: w, request: r, uri: uri, uriVars: u}
 }

--- a/interceptor/introspector_test.go
+++ b/interceptor/introspector_test.go
@@ -1,8 +1,11 @@
 package interceptor
 
 import (
-	"br/tests"
+	"strings"
 	"testing"
+
+	"github.com/aryann/difflib"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func TestIntrospectorBefore(t *testing.T) {
@@ -106,13 +109,13 @@ func TestIntrospectorBeforeUnknownField(t *testing.T) {
 	object.SetField("missing", "field", 17)
 
 	if copied.F != object.F {
-		t.Errorf("Both objects are expected to be equal:\n%s", tests.Diff(copied, object))
+		t.Errorf("Both objects are expected to be equal:\n%s", diff(copied, object))
 	}
 
 	object.SetField("field", "g", 17)
 
 	if copied.F != object.F {
-		t.Errorf("Both objects are expected to be equal:\n%s", tests.Diff(copied, object))
+		t.Errorf("Both objects are expected to be equal:\n%s", diff(copied, object))
 	}
 
 	f := object.Field("missing", "field")
@@ -120,4 +123,8 @@ func TestIntrospectorBeforeUnknownField(t *testing.T) {
 	if f != nil {
 		t.Errorf("The value %#v is supposed to be nil", f)
 	}
+}
+
+func diff(a, b interface{}) []difflib.DiffRecord {
+	return difflib.Diff(strings.SplitAfter(spew.Sdump(a), "\n"), strings.SplitAfter(spew.Sdump(b), "\n"))
 }

--- a/interceptor/json_bench_test.go
+++ b/interceptor/json_bench_test.go
@@ -1,7 +1,6 @@
 package interceptor
 
 import (
-	"br/tests"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -83,7 +82,7 @@ func TestJSONBefore(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, handler.Request) {
 		t.Error("Wrong request")
-		t.Log(tests.Diff(expected, handler.Request))
+		t.Log(diff(expected, handler.Request))
 	}
 }
 

--- a/mux.go
+++ b/mux.go
@@ -26,8 +26,8 @@ type Handy struct {
 
 type Constructor func() Handler
 
-func SetHandlerInfo(h Handler, w http.ResponseWriter, r *http.Request, u URIVars) {
-	h.setRequestInfo(w, r, u)
+func SetHandlerInfo(h Handler, w http.ResponseWriter, r *http.Request, uri string, u URIVars) {
+	h.setRequestInfo(w, r, uri, u)
 }
 
 func NewHandy() *Handy {
@@ -79,7 +79,7 @@ func (handy *Handy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h := route.Handler()
-	SetHandlerInfo(h, w, r, route.URIVars)
+	SetHandlerInfo(h, w, r, route.URI, route.URIVars)
 	interceptors := h.Interceptors()
 	var status int
 

--- a/router.go
+++ b/router.go
@@ -20,6 +20,7 @@ type node struct {
 	parent           *node
 	children         map[string]*node
 	wildcardName     string
+	uri              string
 }
 
 type Router struct {
@@ -87,6 +88,7 @@ func (r *Router) AppendRoute(uri string, h Constructor) error {
 
 			} else if i == len(tokens)-1 {
 				n.handler = h
+				n.uri = uri
 				return nil
 			}
 
@@ -118,6 +120,7 @@ func (r *Router) AppendRoute(uri string, h Constructor) error {
 
 	if r.current != r.root {
 		r.current.handler = h
+		r.current.uri = uri
 	}
 
 	if appended == false {
@@ -141,6 +144,7 @@ func (n *node) findChild(name string) *node {
 type URIVars map[string]string
 
 type RouteMatch struct {
+	URI     string // registered URI pattern for this route
 	URIVars URIVars
 	Handler Constructor
 }
@@ -173,6 +177,7 @@ func (r *Router) Match(uri string) (*RouteMatch, error) {
 		return rt, ErrRouteNotFound
 	}
 
+	rt.URI = current.uri
 	rt.Handler = current.handler
 	return rt, nil
 }

--- a/router_test.go
+++ b/router_test.go
@@ -85,6 +85,10 @@ func TestFindRoute(t *testing.T) {
 		t.Fatal("Cannot find a valid route;", err)
 	}
 
+	if route.URI != "/test" {
+		t.Fatalf("Unexpected URI %s", route.URI)
+	}
+
 	t.Log(route.URIVars)
 }
 
@@ -100,6 +104,10 @@ func TestMatchWithWildcard(t *testing.T) {
 	route, err := rt.Match("/test/foo")
 	if err != nil {
 		t.Fatal("Cannot find a valid route;", err)
+	}
+
+	if route.URI != "/test/{x}" {
+		t.Fatalf("Unexpected URI %s", route.URI)
 	}
 
 	t.Log(route.URIVars)
@@ -133,6 +141,10 @@ func TestMultipleWildCards(t *testing.T) {
 	route, err := rt.Match("/test/foo/bar")
 	if err != nil {
 		t.Fatal("Cannot find a valid route;", err)
+	}
+
+	if route.URI != "/test/{x}/{y}" {
+		t.Fatalf("Unexpected URI %s", route.URI)
 	}
 
 	t.Log(route.URIVars)


### PR DESCRIPTION
Sometimes we need the URI pattern to perform some action in the interceptor. For
example, when we create an ACL for each REST service.