### PR TITLE
Fix introspector in embedded scenario

### DIFF
--- a/interceptor/introspector_test.go
+++ b/interceptor/introspector_test.go
@@ -121,3 +121,24 @@ func TestIntrospectorBeforeUnknownField(t *testing.T) {
 		t.Errorf("The value %#v is supposed to be nil", f)
 	}
 }
+
+func TestIntrospectorBeforeEmbedded(t *testing.T) {
+	object := struct {
+		IntrospectorCompliant
+		dummy
+	}{}
+
+	i := NewIntrospector(&object)
+	i.Before()
+
+	if _, ok := object.Field("field", "f").(*int); !ok {
+		t.Error("It didn't identify the object")
+
+	} else if values := object.KeysWithTag("field"); len(values) != 1 {
+		t.Errorf("Wrong number of values for tag “field”: “%d”", len(values))
+	}
+}
+
+type dummy struct {
+	F int `field:"f"`
+}


### PR DESCRIPTION
Introspector interceptor wasn't identifying tags of fields from embedded
structures. For example:

```go
type A struct {
  Field1 int `field:"field1"`
}

type B struct {
  A
}
```

If we run the introspector on the B structure, the Field1 wouldn't be mapped by
the instrospector.